### PR TITLE
CodeTransformed: fix $mode arg in mkdir() as int

### DIFF
--- a/src/CodeTransformer.php
+++ b/src/CodeTransformer.php
@@ -325,7 +325,7 @@ class CodeTransformer {
         }
 
         if (!is_dir($dirPath)) {
-            mkdir($dirPath, '0777', true);
+            mkdir($dirPath, 0777, true);
         }
 
         return $dirPath;


### PR DESCRIPTION
Fixing `'0777'` vs `0777`.

The former creates a folder with default permissions which does not include read or write perm., and therefore mkdir throws when creating files or subdirectories.